### PR TITLE
Add Alexa relay controller sketch with OTA support

### DIFF
--- a/ESP-Mini-D1-mit-Alexa-und-5-Relais.ino
+++ b/ESP-Mini-D1-mit-Alexa-und-5-Relais.ino
@@ -1,0 +1,178 @@
+#include <ESP8266WiFi.h>
+#include <ESP8266mDNS.h>
+#include <ArduinoOTA.h>
+#include <WiFiManager.h>
+#include <fauxmoESP.h>
+
+// ----------- Konfiguration ------------
+constexpr char OTA_HOSTNAME[] = "jalousie-controller";
+constexpr char CONFIG_AP_NAME[] = "Jalousie-Konfigurator";
+
+constexpr uint8_t RELAY_PINS[] = {D1, D2, D3, D4, D5};
+constexpr size_t RELAY_COUNT = sizeof(RELAY_PINS) / sizeof(RELAY_PINS[0]);
+
+// Die Relais vieler Boards sind aktiv LOW. Falls Ihre Relais aktiv HIGH sind,
+// bitte RELAY_ACTIVE_STATE auf HIGH ändern.
+constexpr uint8_t RELAY_ACTIVE_STATE = LOW;
+constexpr uint8_t RELAY_INACTIVE_STATE =
+    (RELAY_ACTIVE_STATE == LOW) ? HIGH : LOW;
+
+constexpr uint32_t RELAY_PULSE_DURATION_MS = 1000UL;  // 1 Sekunde
+
+const char *const ALEXA_DEVICE_NAMES[RELAY_COUNT] = {
+    "Jalousie eins runter",
+    "Jalousie eins hoch",
+    "Jalousie zwei runter",
+    "Jalousie zwei hoch",
+    "Jalousie stopp"};
+
+struct RelayTask {
+  bool active = false;
+  unsigned long startMillis = 0;
+};
+
+RelayTask relayTasks[RELAY_COUNT];
+
+fauxmoESP fauxmo;
+bool servicesInitialised = false;
+
+// Forward-Deklarationen
+void triggerRelay(size_t index);
+void handleRelayTasks();
+void configureRelays();
+void setupAlexaIntegration();
+void setupOTA();
+void beginNetworkServices();
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println();
+  Serial.println(F("ESP Mini D1 Jalousie-Steuerung startet"));
+
+  configureRelays();
+
+  WiFi.mode(WIFI_STA);
+  WiFi.setAutoReconnect(true);
+  WiFi.persistent(true);
+
+  WiFiManager wifiManager;
+  wifiManager.setClass("invert");  // Dunkles Design für das Portal
+  wifiManager.setConfigPortalTimeout(0);  // kein automatischer Timeout
+  wifiManager.setWiFiAutoReconnect(true);
+
+  if (wifiManager.autoConnect(CONFIG_AP_NAME)) {
+    Serial.print(F("Mit WLAN verbunden: "));
+    Serial.println(WiFi.SSID());
+  } else {
+    Serial.println(F("Kein WLAN verbunden. Konfigurationsportal bleibt aktiv."));
+  }
+}
+
+void loop() {
+  if (WiFi.status() == WL_CONNECTED) {
+    if (!servicesInitialised) {
+      beginNetworkServices();
+    }
+    ArduinoOTA.handle();
+    fauxmo.handle();
+  }
+
+  handleRelayTasks();
+}
+
+void configureRelays() {
+  for (size_t i = 0; i < RELAY_COUNT; ++i) {
+    pinMode(RELAY_PINS[i], OUTPUT);
+    digitalWrite(RELAY_PINS[i], RELAY_INACTIVE_STATE);
+    relayTasks[i].active = false;
+  }
+}
+
+void beginNetworkServices() {
+  setupOTA();
+  setupAlexaIntegration();
+  servicesInitialised = true;
+}
+
+void setupOTA() {
+  ArduinoOTA.setHostname(OTA_HOSTNAME);
+
+  ArduinoOTA.onStart([]() {
+    Serial.println(F("OTA Update startet"));
+  });
+
+  ArduinoOTA.onEnd([]() {
+    Serial.println(F("OTA Update abgeschlossen"));
+  });
+
+  ArduinoOTA.onError([](ota_error_t error) {
+    Serial.print(F("OTA Fehler: "));
+    Serial.println(error);
+  });
+
+  ArduinoOTA.begin();
+  Serial.println(F("OTA bereit"));
+}
+
+void setupAlexaIntegration() {
+  fauxmo.createServer(true);
+  fauxmo.setPort(80);  // Standard-Port für Alexa/Wemo
+  fauxmo.enable(true);
+
+  fauxmo.onSetState([](unsigned char device_id, const char *device_name,
+                       bool state, unsigned char value) {
+    Serial.print(F("Alexa-Befehl: "));
+    Serial.print(device_name);
+    Serial.print(F(" -> "));
+    Serial.println(state ? F("EIN") : F("AUS"));
+
+    if (state && device_id < RELAY_COUNT) {
+      triggerRelay(device_id);
+    }
+  });
+
+  for (size_t i = 0; i < RELAY_COUNT; ++i) {
+    uint8_t id = fauxmo.addDevice(ALEXA_DEVICE_NAMES[i]);
+    Serial.print(F("Alexa-Gerät registriert: "));
+    Serial.print(ALEXA_DEVICE_NAMES[i]);
+    Serial.print(F(" (ID: "));
+    Serial.print(id);
+    Serial.println(F(")"));
+  }
+
+  Serial.println(F("Alexa-Integration bereit"));
+}
+
+void triggerRelay(size_t index) {
+  if (index >= RELAY_COUNT) {
+    return;
+  }
+
+  RelayTask &task = relayTasks[index];
+  task.active = true;
+  task.startMillis = millis();
+  digitalWrite(RELAY_PINS[index], RELAY_ACTIVE_STATE);
+
+  Serial.print(F("Relais "));
+  Serial.print(index + 1);
+  Serial.println(F(" aktiviert"));
+}
+
+void handleRelayTasks() {
+  const unsigned long now = millis();
+
+  for (size_t i = 0; i < RELAY_COUNT; ++i) {
+    RelayTask &task = relayTasks[i];
+    if (!task.active) {
+      continue;
+    }
+
+    if (now - task.startMillis >= RELAY_PULSE_DURATION_MS) {
+      digitalWrite(RELAY_PINS[i], RELAY_INACTIVE_STATE);
+      task.active = false;
+      Serial.print(F("Relais "));
+      Serial.print(i + 1);
+      Serial.println(F(" deaktiviert"));
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,62 @@
-# ESP-Mini-D1-mit-Alexa-und-5-Relais
+# ESP Mini D1 mit Alexa und fünf Relais
 
-Hier erstelle ich ein ESP Projekt, was ein ESP Mini D1 mit 5 Relais über Alexa schaltet.
+Dieses Projekt stellt einen vollständigen Arduino-Sketch bereit, der einen
+Wemos/ESP8266 Mini D1 mit fünf Relais über Amazon Alexa steuern kann. Jeder
+Relaisausgang arbeitet als Taster und wird für eine Sekunde aktiviert, um
+Rollladenantriebe oder ähnliche Steuerungen zu bedienen.
 
-Projekt ist noch in arbeit
+## Funktionsumfang
+
+- **Alexa-Steuerung:** Die fünf Relais erscheinen als einzelne Geräte
+  (Wemo-kompatibel) in Alexa und lassen sich bequem per Sprachbefehl schalten.
+- **Tasterbetrieb:** Jeder Befehl aktiviert das zugehörige Relais für genau eine
+  Sekunde, ohne `delay()`-Aufrufe zu verwenden.
+- **WLAN-Konfiguration per Webportal:** Wenn das Gerät keine gespeicherten
+  WLAN-Zugangsdaten findet oder keine Verbindung herstellen kann, startet es
+  einen eigenen Access Point (`Jalousie-Konfigurator`) mit einem
+  Konfigurationsportal.
+- **OTA-Updates:** Firmware-Aktualisierungen lassen sich komfortabel über das
+  Netzwerk durchführen, ohne ein USB-Kabel anschließen zu müssen.
+
+## Hardware-Zuordnung
+
+| Relais | Funktion                                      | ESP8266-Pin |
+|--------|-----------------------------------------------|-------------|
+| 1      | Jalousie 1 schließt                           | D1          |
+| 2      | Jalousie 1 öffnet                             | D2          |
+| 3      | Jalousie 2 schließt                           | D3          |
+| 4      | Jalousie 2 öffnet                             | D4          |
+| 5      | Stop für Jalousie 1 und 2                     | D5          |
+
+> Hinweis: Viele Relais-Boards arbeiten aktiv **LOW**. Falls Ihr Modul aktiv
+> HIGH geschaltet wird, kann dies im Sketch mit der Konstante
+> `RELAY_ACTIVE_STATE` angepasst werden.
+
+## Voraussetzungen
+
+Installiere vor dem Kompilieren in der Arduino IDE folgende Bibliotheken über
+den Bibliotheksverwalter oder als ZIP-Download:
+
+- **fauxmoESP** – stellt die Wemo-Emulation für Alexa bereit.
+- **WiFiManager** – erzeugt das Konfigurationsportal für WLAN-Zugangsdaten.
+
+Der Sketch befindet sich in der Datei
+[`ESP-Mini-D1-mit-Alexa-und-5-Relais.ino`](ESP-Mini-D1-mit-Alexa-und-5-Relais.ino).
+Öffne den Ordner in der Arduino IDE, wähle als Board „LOLIN(WEMOS) D1 R2 & mini“
+oder ein kompatibles ESP8266-Board und lade die Firmware hoch.
+
+## OTA und Alexa-Ersteinrichtung
+
+1. **WLAN einrichten:** Nach dem ersten Start verbindet sich der ESP mit dem
+   Access Point `Jalousie-Konfigurator`. Verbinde dich mit diesem Netzwerk und
+   öffne die Konfigurationsseite (normalerweise `http://192.168.4.1/`), um deine
+   WLAN-Zugangsdaten zu hinterlegen.
+2. **Alexa-Geräte suchen:** Sobald der Controller im Heimnetz eingebunden ist,
+   lasse Alexa nach neuen Geräten suchen. Es erscheinen fünf Schalter mit den
+   Namen „Jalousie eins runter/hoch“, „Jalousie zwei runter/hoch“ sowie
+   „Jalousie stopp“.
+3. **OTA verwenden:** Für zukünftige Firmware-Updates genügt es, in der Arduino
+   IDE unter „Werkzeuge → Port“ den neuen Netzwerkport (Hostname
+   `jalousie-controller`) auszuwählen.
+
+Viel Erfolg beim Automatisieren deiner Rollläden!


### PR DESCRIPTION
## Summary
- add Arduino sketch for the ESP8266 D1 mini that controls five relays as one-second pulse buttons via Alexa
- integrate WiFiManager for configuration portal when no Wi-Fi credentials are available and ArduinoOTA for wireless updates
- document hardware mapping, required libraries, and setup steps in the README

## Testing
- not run (Arduino sketch)


------
https://chatgpt.com/codex/tasks/task_e_68caebbea0708321aff942a512ef0dc4